### PR TITLE
accounts.IPAddressRecord.ip_address: (fields.W900) IPAddressField has…

### DIFF
--- a/accounts/abstract_models.py
+++ b/accounts/abstract_models.py
@@ -454,7 +454,7 @@ class Transaction(models.Model):
 
 
 class IPAddressRecord(models.Model):
-    ip_address = models.IPAddressField(_("IP address"), unique=True)
+    ip_address = models.GenericIPAddressField(_("IP address"), unique=True)
     total_failures = models.PositiveIntegerField(default=0)
     consecutive_failures = models.PositiveIntegerField(default=0)
     date_created = models.DateTimeField(auto_now_add=True)

--- a/accounts/migrations/0003_auto_20150917_0857.py
+++ b/accounts/migrations/0003_auto_20150917_0857.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0002_core_accounts'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ipaddressrecord',
+            name='ip_address',
+            field=models.GenericIPAddressField(unique=True, verbose_name='IP address'),
+        ),
+    ]


### PR DESCRIPTION
… been deprecated. Support for it (except in historical migrations) will be removed in Django 1.9.

```
    HINT: Use GenericIPAddressField instead.
```
